### PR TITLE
Follow redirects when wrong company permalink

### DIFF
--- a/lib/crunchbase/api.rb
+++ b/lib/crunchbase/api.rb
@@ -43,11 +43,9 @@ module Crunchbase
     # Raises CrunchException if the returned JSON indicates an error.
     def self.fetch(permalink, object_name)
       uri = CB_URL + "#{object_name}/#{permalink}.js"
-
       resp = Timeout::timeout(5) {
         fetch_but_follow_redirects(uri, 5)
       }
-
       j = parser.parse(resp.body)
       raise CrunchException, j["error"] if j["error"]
       return j
@@ -78,11 +76,3 @@ module Crunchbase
 
   end
 end
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Example "adobe", versus crunchbase permalink "adobe-systems" was failing because Crunchbase was returning a redirect, which the library was not following.

Add : http://stackoverflow.com/questions/6934185/ruby-net-http-following-redirects
